### PR TITLE
feat: select instruction

### DIFF
--- a/packages/mlogls/src/parser/nodes.ts
+++ b/packages/mlogls/src/parser/nodes.ts
@@ -1256,6 +1256,35 @@ export class JumpInstruction extends InstructionNode<
   }
 }
 
+export class SelectInstruction extends InstructionNode<
+  DataOf<typeof SelectInstruction>
+> {
+  descriptor = SelectInstruction.descriptor;
+
+  static readonly descriptor = createOverloadDescriptor({
+    name: "select",
+    pre: {
+      result: { isOutput: true },
+    },
+    overloads: {
+      equal: { x: {}, y: {}, a: {}, b: {} },
+      notEqual: { x: {}, y: {}, a: {}, b: {} },
+      lessThan: { x: {}, y: {}, a: {}, b: {} },
+      lessThanEq: { x: {}, y: {}, a: {}, b: {} },
+      greaterThan: { x: {}, y: {}, a: {}, b: {} },
+      greaterThanEq: { x: {}, y: {}, a: {}, b: {} },
+      strictEqual: { x: {}, y: {}, a: {}, b: {} },
+      always: { x: {}, y: {}, a: {} },
+    },
+  });
+
+  static parse(this: void, line: TokenLine) {
+    const data = SelectInstruction.descriptor.parse(line.tokens);
+
+    return new SelectInstruction(line, ...data);
+  }
+}
+
 export class UnitBindInstruction extends InstructionNode<
   DataOf<typeof UnitBindInstruction>
 > {
@@ -2383,6 +2412,7 @@ const instructionParsers: Record<string, (line: TokenLine) => SyntaxNode> = {
   unpackcolor: UnpackColorInstruction.parse,
   end: EndInstruction.parse,
   jump: JumpInstruction.parse,
+  select: SelectInstruction.parse,
   ubind: UnitBindInstruction.parse,
   ucontrol: UnitControlInstruction.parse,
   uradar: UnitRadarinstruction.parse,

--- a/packages/mlogls/src/parser/nodes.ts
+++ b/packages/mlogls/src/parser/nodes.ts
@@ -1267,14 +1267,14 @@ export class SelectInstruction extends InstructionNode<
       result: { isOutput: true },
     },
     overloads: {
-      equal: { x: {}, y: {}, a: {}, b: {} },
-      notEqual: { x: {}, y: {}, a: {}, b: {} },
-      lessThan: { x: {}, y: {}, a: {}, b: {} },
-      lessThanEq: { x: {}, y: {}, a: {}, b: {} },
-      greaterThan: { x: {}, y: {}, a: {}, b: {} },
-      greaterThanEq: { x: {}, y: {}, a: {}, b: {} },
-      strictEqual: { x: {}, y: {}, a: {}, b: {} },
-      always: { x: {}, y: {}, a: {} },
+      equal: { x: {}, y: {}, whenTrue: {}, whenFalse: {} },
+      notEqual: { x: {}, y: {}, whenTrue: {}, whenFalse: {} },
+      lessThan: { x: {}, y: {}, whenTrue: {}, whenFalse: {} },
+      lessThanEq: { x: {}, y: {}, whenTrue: {}, whenFalse: {} },
+      greaterThan: { x: {}, y: {}, whenTrue: {}, whenFalse: {} },
+      greaterThanEq: { x: {}, y: {}, whenTrue: {}, whenFalse: {} },
+      strictEqual: { x: {}, y: {}, whenTrue: {}, whenFalse: {} },
+      always: { _x: {}, _y: {}, value: {} },
     },
   });
 


### PR DESCRIPTION
Tiny PR to add support for the new `select` instruction in b150. I tested it locally, seems to work as expected.

I'm not entirely sure about the argument names though. I chose `x` and `y` for the first two to match `jump`, since it uses the same conditions; and `a` and `b` are the default names ingame. I'm not sure if `a` and `b` are fine, or if something like `trueValue` and `falseValue`, or `then` and `else` maybe, would be better?

<img width="928" height="169" alt="image" src="https://github.com/user-attachments/assets/25fda72d-d40b-475c-bb17-e06410b15583" />

Also unsure about the variables for `always`. This is what it looks like ingame:

<img width="477" height="179" alt="image" src="https://github.com/user-attachments/assets/a010e279-9ded-4868-aa86-5c71f7b82db8" />

And this is the exported code:

```
select result always x false a b
```

`x` and `y` aren't visible ingame, but I think they still need to be specified in code, otherwise `a` and `b` are in the wrong positions. `b` *is* visible ingame, but the value is never used, so arguably it shouldn't be visible.
